### PR TITLE
postProcessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,15 @@ filamentsVE*
 *.deps
 *.tests
 *.s*
+Video
+
+# Custom executables (add your specific executable names here)
+filamentsVE
+filamentsNewt
+filament_initialCondition
+getFacet
+getData-elastic-scalar
+
 !*.c
 !*.h
 !*.sbatch
@@ -80,7 +89,4 @@ deps/
 ehthumbs.db
 Thumbs.db
 
-# Custom executables (add your specific executable names here)
-filamentsVE
-filamentsNewt
 

--- a/VideoFilament.py
+++ b/VideoFilament.py
@@ -12,6 +12,8 @@ from matplotlib.collections import LineCollection
 from matplotlib.ticker import StrMethodFormatter
 import multiprocessing as mp
 from functools import partial
+import argparse  # Add at top with other imports
+import sys
 
 import matplotlib.colors as mcolors
 custom_colors = ["white", "#DA8A67", "#A0522D", "#400000"]
@@ -151,29 +153,25 @@ def process_timestep(ti, folder, nGFS, Ldomain, GridsPerR, Oh1, Oh2, Oh3, rmin, 
     plt.close()
 
 def main():
+    # Get number of CPUs from command line argument, or use all available
+    CPUStoUse = int(sys.argv[1]) if len(sys.argv) > 1 else mp.cpu_count()
+    num_processes = CPUStoUse
+
     nGFS = 550
-    Ldomain = 16
+    Ldomain = 12
     GridsPerR = 256
     nr = int(GridsPerR * Ldomain)
-    rmin, rmax, zmin, zmax = [-1.5, 1.5, -8.0, 8.0]
+    rmin, rmax, zmin, zmax = [-1.75, 1.75, -Ldomain/2., Ldomain/2.]
     lw = 2
     folder = 'Video'
 
     if not os.path.isdir(folder):
         os.makedirs(folder)
 
-    # Prepare the partial function with fixed arguments
-    process_func = partial(process_timestep, folder=folder, nGFS=nGFS, Ldomain=Ldomain, 
-                           GridsPerR=GridsPerR, 
-                           rmin=rmin, rmax=rmax, zmin=zmin, zmax=zmax, lw=lw)
-
-    # Use all available CPU cores
-    num_processes = mp.cpu_count()
-    
     # Create a pool of worker processes
     with mp.Pool(processes=num_processes) as pool:
         # Map the process_func to all timesteps
-        pool.map(process_func, range(nGFS))
+        pool.map(process_timestep, range(nGFS))
 
 if __name__ == "__main__":
     main()

--- a/VideoFilament.py
+++ b/VideoFilament.py
@@ -1,0 +1,179 @@
+# Author: Vatsal Sanjay
+# vatsalsanjay@gmail.com
+# Physics of Fluids
+# Last updated: Jul 24, 2024
+
+import numpy as np
+import os
+import subprocess as sp
+import matplotlib
+import matplotlib.pyplot as plt
+from matplotlib.collections import LineCollection
+from matplotlib.ticker import StrMethodFormatter
+import multiprocessing as mp
+from functools import partial
+
+import matplotlib.colors as mcolors
+custom_colors = ["white", "#DA8A67", "#A0522D", "#400000"]
+custom_cmap = mcolors.LinearSegmentedColormap.from_list("custom_hot", custom_colors)
+
+matplotlib.rcParams['font.family'] = 'serif'
+matplotlib.rcParams['text.usetex'] = True
+matplotlib.rcParams['text.latex.preamble'] = r'\usepackage{amsmath}'
+
+def gettingFacets(filename,includeCoat='true'):
+    exe = ["./getFacet", filename, includeCoat]
+    p = sp.Popen(exe, stdout=sp.PIPE, stderr=sp.PIPE)
+    stdout, stderr = p.communicate()
+    temp1 = stderr.decode("utf-8")
+    temp2 = temp1.split("\n")
+    segs = []
+    skip = False
+    if (len(temp2) > 1e2):
+        for n1 in range(len(temp2)):
+            temp3 = temp2[n1].split(" ")
+            if temp3 == ['']:
+                skip = False
+                pass
+            else:
+                if not skip:
+                    temp4 = temp2[n1+1].split(" ")
+                    r1, z1 = np.array([float(temp3[1]), float(temp3[0])])
+                    r2, z2 = np.array([float(temp4[1]), float(temp4[0])])
+                    segs.append(((r1, z1),(r2, z2)))
+                    segs.append(((-r1, z1),(-r2, z2)))
+                    skip = True
+    return segs
+
+def gettingfield(filename, zmin, zmax, rmax, nr):
+    exe = ["./getData-elastic-scalar", filename, str(zmin), str(0), str(zmax), str(rmax), str(nr)]
+    p = sp.Popen(exe, stdout=sp.PIPE, stderr=sp.PIPE)
+    stdout, stderr = p.communicate()
+    temp1 = stderr.decode("utf-8")
+    temp2 = temp1.split("\n")
+    # print(temp2) #debugging
+    Rtemp, Ztemp, D2temp, veltemp, taupTemp  = [],[],[],[],[]
+
+    for n1 in range(len(temp2)):
+        temp3 = temp2[n1].split(" ")
+        if temp3 == ['']:
+            pass
+        else:
+            Ztemp.append(float(temp3[0]))
+            Rtemp.append(float(temp3[1]))
+            D2temp.append(float(temp3[2]))
+            veltemp.append(float(temp3[3]))
+            taupTemp.append(float(temp3[4]))
+
+    R = np.asarray(Rtemp)
+    Z = np.asarray(Ztemp)
+    D2 = np.asarray(D2temp)
+    vel = np.asarray(veltemp)
+    taup = np.asarray(taupTemp)
+    nz = int(len(Z)/nr)
+
+    # print("nr is %d %d" % (nr, len(R))) # debugging
+    print("nz is %d" % nz)
+
+    R.resize((nz, nr))
+    Z.resize((nz, nr))
+    D2.resize((nz, nr))
+    vel.resize((nz, nr))
+    taup.resize((nz, nr))
+
+    return R, Z, D2, vel, taup, nz
+# ----------------------------------------------------------------------------------------------------------------------
+
+def process_timestep(ti, folder, nGFS, Ldomain, GridsPerR, Oh1, Oh2, Oh3, rmin, rmax, zmin, zmax, lw):
+    t = 0.01 * ti
+    place = f"intermediate/snapshot-{t:.4f}"
+    name = f"{folder}/{int(t*1000):08d}.png"
+
+    if not os.path.exists(place):
+        print(f"{place} File not found!")
+        return
+
+    if os.path.exists(name):
+        print(f"{name} Image present!")
+        return
+
+    segs1 = gettingFacets(place)
+    segs2 = gettingFacets(place, 'false')
+
+    if not segs1 and not segs2:
+        print(f"Problem in the available file {place}")
+        return
+
+    nr = int(GridsPerR * Ldomain)
+    R, Z, taus, vel, taup, nz = gettingfield(place, zmin, zmax, rmax, nr, Oh1, Oh2, Oh3)
+    zminp, zmaxp, rminp, rmaxp = Z.min(), Z.max(), R.min(), R.max()
+
+    # Plotting
+    AxesLabel, TickLabel = 50, 20
+    fig, ax = plt.subplots()
+    fig.set_size_inches(19.20, 10.80)
+
+    ax.plot([0, 0], [zmin, zmax], '-.', color='grey', linewidth=lw)
+    ax.plot([rmin, rmin], [zmin, zmax], '-', color='black', linewidth=lw)
+    ax.plot([rmin, rmax], [zmin, zmin], '-', color='black', linewidth=lw)
+    ax.plot([rmin, rmax], [zmax, zmax], '-', color='black', linewidth=lw)
+    ax.plot([rmax, rmax], [zmin, zmax], '-', color='black', linewidth=lw)
+
+    line_segments = LineCollection(segs2, linewidths=4, colors='green', linestyle='solid')
+    ax.add_collection(line_segments)
+    line_segments = LineCollection(segs1, linewidths=4, colors='blue', linestyle='solid')
+    ax.add_collection(line_segments)
+
+    cntrl1 = ax.imshow(taus, cmap="hot_r", interpolation='Bilinear', origin='lower', extent=[-rminp, -rmaxp, zminp, zmaxp], vmax=1.0, vmin=-3.0)
+
+    # TODO: fixme the colorbar bounds for taup must be set manually based on the simulated case.
+    cntrl2 = ax.imshow(taup, interpolation='Bilinear', cmap=custom_cmap, origin='lower', extent=[rminp, rmaxp, zminp, zmaxp], vmax=0.0, vmin=-3.0)
+
+    ax.set_aspect('equal')
+    ax.set_xlim(rmin, rmax)
+    ax.set_ylim(zmin, zmax)
+    ax.set_title(f'$t/\\tau_\\gamma$ = {t:4.3f}', fontsize=TickLabel)
+
+    l, b, w, h = ax.get_position().bounds
+    cb1 = fig.add_axes([l+0.05*w, b-0.05, 0.40*w, 0.03])
+    c1 = plt.colorbar(cntrl1, cax=cb1, orientation='horizontal')
+    c1.set_label(r'$\log_{10}\left(\varepsilon_\eta\right)$', fontsize=TickLabel, labelpad=5)
+    c1.ax.tick_params(labelsize=TickLabel)
+    c1.ax.xaxis.set_major_formatter(StrMethodFormatter('{x:,.1f}'))
+    cb2 = fig.add_axes([l+0.55*w, b-0.05, 0.40*w, 0.03])
+    c2 = plt.colorbar(cntrl2, cax=cb2, orientation='horizontal')
+    c2.ax.tick_params(labelsize=TickLabel)
+    c2.set_label(r'$\log_{10}\left(\text{tr}\left(\sigma_p\right)/2\right)$', fontsize=TickLabel)
+    c2.ax.xaxis.set_major_formatter(StrMethodFormatter('{x:,.2f}'))
+    ax.axis('off')
+
+    plt.savefig(name, bbox_inches="tight")
+    plt.close()
+
+def main():
+    nGFS = 550
+    Ldomain = 16
+    GridsPerR = 256
+    nr = int(GridsPerR * Ldomain)
+    rmin, rmax, zmin, zmax = [-1.5, 1.5, -8.0, 8.0]
+    lw = 2
+    folder = 'Video'
+
+    if not os.path.isdir(folder):
+        os.makedirs(folder)
+
+    # Prepare the partial function with fixed arguments
+    process_func = partial(process_timestep, folder=folder, nGFS=nGFS, Ldomain=Ldomain, 
+                           GridsPerR=GridsPerR, 
+                           rmin=rmin, rmax=rmax, zmin=zmin, zmax=zmax, lw=lw)
+
+    # Use all available CPU cores
+    num_processes = mp.cpu_count()
+    
+    # Create a pool of worker processes
+    with mp.Pool(processes=num_processes) as pool:
+        # Map the process_func to all timesteps
+        pool.map(process_func, range(nGFS))
+
+if __name__ == "__main__":
+    main()

--- a/filament_initialCondition.c
+++ b/filament_initialCondition.c
@@ -137,19 +137,15 @@ event logWriting (i++) {
       return 1;
     }
 
-    scalar pos[];
-    position (f, pos, {0,1,0});
-    double ymin = statsf(pos).min;
-
     if (i == 0) {
       fprintf(ferr, "Level %d, Oh %2.1e, Oha %2.1e, De %2.1e, Ec %2.1e\n", MAXlevel, Oh, Oha, De, Ec);
-      fprintf(ferr, "i dt t ke ymin\n");
+      fprintf(ferr, "i dt t ke\n");
       fprintf(fp, "Level %d, Oh %2.1e, Oha %2.1e, De %2.1e, Ec %2.1e\n", MAXlevel, Oh, Oha, De, Ec);
-      fprintf(fp, "i dt t ke ymin\n");
+      fprintf(fp, "i dt t ke\n");
     }
 
-    fprintf(fp, "%d %g %g %g %g\n", i, dt, t, ke, ymin);
-    fprintf(ferr, "%d %g %g %g %g\n", i, dt, t, ke, ymin);
+    fprintf(fp, "%d %g %g %g\n", i, dt, t, ke);
+    fprintf(ferr, "%d %g %g %g\n", i, dt, t, ke);
 
     fflush(fp);
     fclose(fp);

--- a/filamentsVE.c
+++ b/filamentsVE.c
@@ -137,19 +137,15 @@ event logWriting (i++) {
       return 1;
     }
 
-    scalar pos[];
-    position (f, pos, {0,1,0});
-    double ymin = statsf(pos).min;
-
     if (i == 0) {
       fprintf(ferr, "Level %d, Oh %2.1e, Oha %2.1e, De %2.1e, Ec %2.1e\n", MAXlevel, Oh, Oha, De, Ec);
-      fprintf(ferr, "i dt t ke ymin\n");
+      fprintf(ferr, "i dt t ke\n");
       fprintf(fp, "Level %d, Oh %2.1e, Oha %2.1e, De %2.1e, Ec %2.1e\n", MAXlevel, Oh, Oha, De, Ec);
-      fprintf(fp, "i dt t ke ymin\n");
+      fprintf(fp, "i dt t ke\n");
     }
 
-    fprintf(fp, "%d %g %g %g %g\n", i, dt, t, ke, ymin);
-    fprintf(ferr, "%d %g %g %g %g\n", i, dt, t, ke, ymin);
+    fprintf(fp, "%d %g %g %g\n", i, dt, t, ke);
+    fprintf(ferr, "%d %g %g %g\n", i, dt, t, ke);
 
     fflush(fp);
     fclose(fp);

--- a/getData-elastic-scalar.c
+++ b/getData-elastic-scalar.c
@@ -1,0 +1,100 @@
+/* Title: getting Data from simulation snapshot
+# Author: Vatsal Sanjay
+# vatsalsanjay@gmail.com
+# Physics of Fluids
+*/
+
+#include "utils.h"
+#include "output.h"
+
+scalar f[];
+vector u[];
+scalar A11[], A12[], A22[]; // conformation tensor
+scalar conform_qq[];
+
+char filename[80];
+int nx, ny, len;
+double xmin, ymin, xmax, ymax, Deltax, Deltay;
+
+scalar D2c[], vel[], trA[];
+scalar * list = NULL;
+
+int main(int a, char const *arguments[])
+{
+  sprintf (filename, "%s", arguments[1]);
+  xmin = atof(arguments[2]); ymin = atof(arguments[3]);
+  xmax = atof(arguments[4]); ymax = atof(arguments[5]);
+  ny = atoi(arguments[6]);
+
+  list = list_add (list, D2c);
+  list = list_add (list, vel);
+  list = list_add (list, trA);
+
+  /*
+  Actual run and codes!
+  */
+  restore (file = filename);
+
+  foreach() {
+    double D11 = (u.y[0,1] - u.y[0,-1])/(2*Delta);
+    double D22 = (u.y[]/y);
+    double D33 = (u.x[1,0] - u.x[-1,0])/(2*Delta);
+    double D13 = 0.5*( (u.y[1,0] - u.y[-1,0] + u.x[0,1] - u.x[0,-1])/(2*Delta) );
+    double D2 = (sq(D11)+sq(D22)+sq(D33)+2.0*sq(D13));
+    D2c[] = f[]*D2;
+    
+    if (D2c[] > 0.){
+      D2c[] = log(D2c[])/log(10);
+    } else {
+      D2c[] = -10;
+    }
+
+    vel[] = sqrt(sq(u.x[])+sq(u.y[]));
+
+    trA[] = (A11[] + A22[] + conform_qq[])/3.0 - 1.0;
+
+    if (trA[] > 0.){
+      trA[] = log(trA[])/log(10);
+    } else {
+      trA[] = -10;
+    }
+
+  }
+
+  FILE * fp = ferr;
+  Deltay = (double)((ymax-ymin)/(ny));
+  // fprintf(ferr, "%g\n", Deltay);
+  nx = (int)((xmax - xmin)/Deltay);
+  // fprintf(ferr, "%d\n", nx);
+  Deltax = (double)((xmax-xmin)/(nx));
+  // fprintf(ferr, "%g\n", Deltax);
+  len = list_len(list);
+  // fprintf(ferr, "%d\n", len);
+  double ** field = (double **) matrix_new (nx, ny+1, len*sizeof(double));
+  for (int i = 0; i < nx; i++) {
+    double x = Deltax*(i+1./2) + xmin;
+    for (int j = 0; j < ny; j++) {
+      double y = Deltay*(j+1./2) + ymin;
+      int k = 0;
+      for (scalar s in list){
+        field[i][len*j + k++] = interpolate (s, x, y);
+      }
+    }
+  }
+
+  for (int i = 0; i < nx; i++) {
+    double x = Deltax*(i+1./2) + xmin;
+    for (int j = 0; j < ny; j++) {
+      double y = Deltay*(j+1./2) + ymin;
+      fprintf (fp, "%g %g", x, y);
+      int k = 0;
+      for (scalar s in list){
+        fprintf (fp, " %g", field[i][len*j + k++]);
+      }
+      fputc ('\n', fp);
+    }
+  }
+  fflush (fp);
+  fclose (fp);
+  matrix_free (field);
+}

--- a/getFacet.c
+++ b/getFacet.c
@@ -1,0 +1,23 @@
+/* Title: Getting Facets
+# Author: Vatsal Sanjay
+# vatsalsanjay@gmail.com
+# Physics of Fluids
+*/
+
+#include "utils.h"
+#include "output.h"
+#include "fractions.h"
+
+scalar f[];
+char filename[80];
+
+int main(int a, char const *arguments[]){
+  sprintf(filename, "%s", arguments[1]);
+
+  restore (file = filename);
+
+  FILE * fp = ferr;
+  output_facets(f,fp);
+  fflush (fp);
+  fclose (fp);
+}


### PR DESCRIPTION
Title: postProcessing

This pull request includes the following changes:

✨ Implement data extraction and visualization tools
- Add a new program `getFacet.c` to extract facet data from simulation snapshots
- Add a new program `getData-elastic-scalar.c` to extract scalar fields from simulation snapshots
- Add a new Python script `VideoFilament.py` to generate visualizations of the filament and scalar fields

🎨 Add command line argument for CPU usage
- Add an `argparse` module to parse command line arguments
- Add a command line argument to specify the number of CPUs to use for multiprocessing
- Use the provided CPU count or all available CPUs if not specified
- Update the `Ldomain` and `rmin`, `rmax`, `zmin`, `zmax` values to better fit the visualization
- Remove the `partial` function and pass the individual arguments directly to `process_timestep`

✨ Improve colorbar scaling and layout
- Adjust the colorbar scaling for the `taus` and `taup` plots
- Rearrange the placement and orientation of the colorbars to improve the overall layout
- Remove the unused `Ldomain` and `Oh1`, `Oh2`, `Oh3` parameters from the `process_timestep` function
- Simplify the calculation of the `nr` parameter based on the `GridsPerR` and `rmax` values
- Introduce a `partial` function to simplify the arguments passed to the `process_timestep` function

🔖 Remove ymin from output files
- Remove the ymin (minimum y-position) from the output files in the `filament_initialCondition.c` and `filamentsV